### PR TITLE
Upgrade the dependency on Easymock to 3.2

### DIFF
--- a/maven-test-tools/pom.xml
+++ b/maven-test-tools/pom.xml
@@ -39,7 +39,7 @@ under the License.
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>2.5.2</version>
+      <version>3.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/maven-test-tools/src/main/java/org/apache/maven/shared/tools/easymock/MockManager.java
+++ b/maven-test-tools/src/main/java/org/apache/maven/shared/tools/easymock/MockManager.java
@@ -22,22 +22,22 @@ package org.apache.maven.shared.tools.easymock;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.easymock.MockControl;
+import org.easymock.IMocksControl;
 
 /**
- * Manager of MockControl
+ * Manager of IMocksControl
  *
  * @version $Id$
- * @see MockControl
+ * @see IMocksControl
  */
 public class MockManager
 {
-    private List<MockControl> mockControls = new ArrayList<MockControl>();
+    private List<IMocksControl> mockControls = new ArrayList<IMocksControl>();
 
     /**
      * @param control to be add to the manager
      */
-    public void add( MockControl control )
+    public void add( IMocksControl control )
     {
         mockControls.add( control );
     }
@@ -55,7 +55,7 @@ public class MockManager
      */
     public void replayAll()
     {
-        for ( MockControl control : mockControls )
+        for ( IMocksControl control : mockControls )
         {
             control.replay();
         }
@@ -66,7 +66,7 @@ public class MockManager
      */
     public void verifyAll()
     {
-        for ( MockControl control : mockControls )
+        for ( IMocksControl control : mockControls )
         {
             control.verify();
         }


### PR DESCRIPTION
The `MockControl` class used by `MockManager` in the maven-test-tools artifact has been removed from EasyMock starting with version 3.0. This patch updates `MockManager` to use the equivalent class in the latest versions of EasyMock.
