### PR TITLE
[MPLUGINTESTING-62] target maven 3.6.0 and Plexus 2.0.0

### DIFF
--- a/maven-plugin-testing-harness/pom.xml
+++ b/maven-plugin-testing-harness/pom.xml
@@ -50,10 +50,6 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-aether-provider</artifactId>
-    </dependency>
 
     <!-- plexus -->
     <dependency>

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/stubs/StubArtifactCollector.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/stubs/StubArtifactCollector.java
@@ -50,7 +50,8 @@ public class StubArtifactCollector
 
     @Override
     public ArtifactResolutionResult collect( Set<Artifact> artifacts, Artifact originatingArtifact,
-                                             Map managedVersions, ArtifactResolutionRequest repositoryRequest,
+                                             Map<String, Artifact> managedVersions,
+                                             ArtifactResolutionRequest repositoryRequest,
                                              ArtifactMetadataSource source, ArtifactFilter filter,
                                              List<ResolutionListener> listeners,
                                              List<ConflictResolver> conflictResolvers )
@@ -60,7 +61,7 @@ public class StubArtifactCollector
 
     @Override
     public ArtifactResolutionResult collect( Set<Artifact> artifacts, Artifact originatingArtifact,
-                                             Map managedVersions, ArtifactRepository localRepository,
+                                             Map<String, Artifact> managedVersions, ArtifactRepository localRepository,
                                              List<ArtifactRepository> remoteRepositories,
                                              ArtifactMetadataSource source, ArtifactFilter filter,
                                              List<ResolutionListener> listeners,
@@ -71,7 +72,7 @@ public class StubArtifactCollector
 
     @Override
     public ArtifactResolutionResult collect( Set<Artifact> artifacts, Artifact originatingArtifact,
-                                             Map managedVersions, ArtifactRepository localRepository,
+                                             Map<String, Artifact> managedVersions, ArtifactRepository localRepository,
                                              List<ArtifactRepository> remoteRepositories,
                                              ArtifactMetadataSource source, ArtifactFilter filter,
                                              List<ResolutionListener> listeners )

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/stubs/StubArtifactResolver.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/stubs/StubArtifactResolver.java
@@ -150,7 +150,8 @@ public class StubArtifactResolver
      */
     @Override
     public ArtifactResolutionResult resolveTransitively( Set<Artifact> artifacts, Artifact originatingArtifact,
-                                                         Map managedVersions, ArtifactRepository localRepository,
+                                                         Map<String, Artifact> managedVersions,
+                                                         ArtifactRepository localRepository,
                                                          List<ArtifactRepository> remoteRepositories,
                                                          ArtifactMetadataSource source )
         throws ArtifactResolutionException, ArtifactNotFoundException
@@ -164,7 +165,8 @@ public class StubArtifactResolver
      */
     @Override
     public ArtifactResolutionResult resolveTransitively( Set<Artifact> artifacts, Artifact originatingArtifact,
-                                                         Map managedVersions, ArtifactRepository localRepository,
+                                                         Map<String, Artifact> managedVersions,
+                                                         ArtifactRepository localRepository,
                                                          List<ArtifactRepository> remoteRepositories,
                                                          ArtifactMetadataSource source, ArtifactFilter filter )
         throws ArtifactResolutionException, ArtifactNotFoundException
@@ -178,7 +180,8 @@ public class StubArtifactResolver
      */
     @Override
     public ArtifactResolutionResult resolveTransitively( Set<Artifact> artifacts, Artifact originatingArtifact,
-                                                         Map managedVersions, ArtifactRepository localRepository,
+                                                         Map<String, Artifact> managedVersions,
+                                                         ArtifactRepository localRepository,
                                                          List<ArtifactRepository> remoteRepositories,
                                                          ArtifactMetadataSource source, ArtifactFilter filter,
                                                          List<ResolutionListener> listeners )
@@ -207,11 +210,6 @@ public class StubArtifactResolver
     {
         // TODO Auto-generated method stub
         
-    }
-    
-    public ArtifactResolutionResult collect( ArtifactResolutionRequest request )
-    {
-        return null;
     }
 
     @Override

--- a/maven-plugin-testing-harness/src/site/apt/getting-started/index.apt
+++ b/maven-plugin-testing-harness/src/site/apt/getting-started/index.apt
@@ -213,7 +213,7 @@ public class MyMojoTest
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -144,8 +144,8 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <mavenVersion>3.2.5</mavenVersion>
-    <plexusVersion>1.5.5</plexusVersion>
+    <mavenVersion>3.6.0</mavenVersion>
+    <plexusVersion>2.0.0</plexusVersion>
     <maven.site.path>plugin-testing-archives/LATEST</maven.site.path>
     <javaVersion>7</javaVersion>
   </properties>
@@ -177,27 +177,21 @@ under the License.
         <artifactId>maven-plugin-api</artifactId>
         <version>${mavenVersion}</version>
         <scope>provided</scope>
-      </dependency>    
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-aether-provider</artifactId>
-        <version>${mavenVersion}</version>
-        <scope>provided</scope>
-      </dependency>    
+      </dependency>
     
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
         <version>3.0.15</version>
         <scope>provided</scope>
-      </dependency>    
-    
+      </dependency>
+
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.12</version>
         <scope>provided</scope>
-      </dependency>    
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
pretty frustrating that in 2019 people are still targeting ancient Java versions. In this pull request I've set JDK 8 as the target and also updated to a more recent maven api level and updated junit to the newer `org.junit.vintage:junit-vintage-engine` equivelant.

Any change of a new release? 3.3.0 was released years ago