### PR TITLE
Add Github Workflows CI for JDK 7 - 13

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [1.7, 1.8, 9, 10, 11, 12, 13]
+        jdk: [1.7, 1.8, 11, 13]
         #os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -39,5 +39,5 @@ jobs:
       with:
         java-version: ${{ matrix.jdk }}
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn clean verify --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+    name: Test with Java ${{ matrix.jdk }}
+    #runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [1.7, 1.8, 9, 10, 11, 12, 13]
+        #os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.jdk }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.jdk }}
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+


### PR DESCRIPTION
Although the project already has Jenkins for CI it would be really helpful to use the in built Github Actions CI for quick builds and visibility for contributors that don't have visibility of the Jenkins builds.

The workflow in this PR builds with multiple Java versions (7 to 13) and completes in about 3 mins.