### PR TITLE
Allows creating configured mojos initilised with values from the given project pom

### DIFF
--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/MojoRule.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/MojoRule.java
@@ -132,7 +132,7 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupMojo( String goal, String pluginPom )
+    public <T extends Mojo> T lookupMojo( String goal, String pluginPom )
         throws Exception
     {
         return testCase.lookupMojo( goal, pluginPom );
@@ -146,7 +146,7 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupEmptyMojo( String goal, String pluginPom )
+    public <T extends Mojo> T lookupEmptyMojo( String goal, String pluginPom )
         throws Exception
     {
         return testCase.lookupEmptyMojo( goal, new File( pluginPom ) );
@@ -160,7 +160,7 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupMojo( String goal, File pom )
+    public <T extends Mojo> T lookupMojo( String goal, File pom )
         throws Exception
     {
         return testCase.lookupMojo( goal, pom );
@@ -174,26 +174,26 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupEmptyMojo( String goal, File pom )
+    public <T extends Mojo> T lookupEmptyMojo( String goal, File pom )
         throws Exception
     {
         return testCase.lookupEmptyMojo( goal, pom );
     }
 
-    public Mojo lookupMojo( String groupId, String artifactId, String version, String goal,
+    public <T extends Mojo> T lookupMojo( String groupId, String artifactId, String version, String goal,
                                PlexusConfiguration pluginConfiguration )
         throws Exception
     {
         return testCase.lookupMojo( groupId, artifactId, version, goal, pluginConfiguration );
     }
 
-    public Mojo lookupConfiguredMojo( MavenProject project, String goal )
+    public <T extends Mojo> T lookupConfiguredMojo( MavenProject project, String goal )
         throws Exception
     {
         return testCase.lookupConfiguredMojo( project, goal );
     }
 
-    public Mojo lookupConfiguredMojo( MavenSession session, MojoExecution execution )
+    public <T extends Mojo> T lookupConfiguredMojo( MavenSession session, MojoExecution execution )
         throws Exception, ComponentConfigurationException
     {
         return testCase.lookupConfiguredMojo( session, execution );
@@ -221,13 +221,13 @@ public class MojoRule
         return testCase.extractPluginConfiguration( artifactId, pomDom );
     }
 
-    public Mojo configureMojo( Mojo mojo, String artifactId, File pom )
+    public <T extends Mojo> T configureMojo( T mojo, String artifactId, File pom )
         throws Exception
     {
         return testCase.configureMojo( mojo, artifactId, pom );
     }
 
-    public Mojo configureMojo( Mojo mojo, PlexusConfiguration pluginConfiguration )
+    public <T extends Mojo> T configureMojo( T mojo, PlexusConfiguration pluginConfiguration )
         throws Exception
     {
         return testCase.configureMojo( mojo, pluginConfiguration );
@@ -243,7 +243,7 @@ public class MojoRule
      * @return object value of variable
      * @throws IllegalArgumentException
      */
-    public Object getVariableValueFromObject( Object object, String variable )
+    public <T> T getVariableValueFromObject( Object object, String variable )
         throws IllegalAccessException
     {
         return testCase.getVariableValueFromObject( object, variable );
@@ -286,7 +286,7 @@ public class MojoRule
      * @param value
      * @throws IllegalAccessException
      */
-    public void setVariableValueToObject( Object object, String variable, Object value )
+    public <T> void setVariableValueToObject( Object object, String variable, T value )
         throws IllegalAccessException
     {
         testCase.setVariableValueToObject( object, variable, value );
@@ -350,13 +350,29 @@ public class MojoRule
     /**
      * @since 3.1.0
      */
-    public Mojo lookupConfiguredMojo( File basedir, String goal )
+    public <T extends Mojo> T lookupConfiguredMojo( File basedir, String goal )
         throws Exception, ComponentConfigurationException
     {
         MavenProject project = readMavenProject( basedir );
         MavenSession session = newMavenSession( project );
         MojoExecution execution = newMojoExecution( goal );
         return lookupConfiguredMojo( session, execution );
+    }
+
+
+    /**
+     * Returns a fully configured mojo, initialized with the project pom
+     *
+     * @param pomFile POM file containing the requested goal configuration
+     * @param goal requested goal
+     * @return configured Mojo initialised with the project from MOJO and the default parameter settings
+     * @throws Exception
+     * @since 3.4
+     */
+    public <T extends Mojo> T lookupInitializedMojo( File pomFile, String goal )
+            throws Exception
+    {
+        return testCase.lookupInitializedMojo( pomFile, goal );
     }
 
     /**

--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/MojoRuleTest.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/MojoRuleTest.java
@@ -19,17 +19,20 @@ package org.apache.maven.plugin.testing;
  * under the License.
  */
 
+import java.io.File;
+import java.io.StringReader;
+import java.util.Map;
+
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
-
-import java.io.StringReader;
-import java.util.Map;
-import org.junit.Rule;
-
-import static org.junit.Assert.*;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mirko Friedenhagen
@@ -95,7 +98,7 @@ public class MojoRuleTest
     {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         assertEquals( "valueOne", mojo.getKeyOne() );
 
@@ -111,7 +114,7 @@ public class MojoRuleTest
     {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         assertEquals( "valueOne", rule.getVariableValueFromObject( mojo, "keyOne" ) );
 
@@ -127,7 +130,7 @@ public class MojoRuleTest
      {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         Map<String, Object> map = rule.getVariablesAndValuesFromObject( mojo );
 
@@ -145,7 +148,7 @@ public class MojoRuleTest
     {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         rule.setVariableValueToObject( mojo, "keyOne", "myValueOne" );
 
@@ -165,4 +168,23 @@ public class MojoRuleTest
     {
         assertTrue( "before executed because WithMojo annotation was not added", beforeWasCalled );
     }
+
+    /**
+     * @throws Exception if any
+     */
+
+    /**
+     * @throws Exception if any
+     */
+    @Test
+    public void testLookupInitializedMojo()
+            throws Exception
+    {
+        File pomFile = new File( "src/test/projects/property/pom.xml" );
+        ParametersMojo mojo = rule.lookupInitializedMojo( pomFile, "parameters" );
+        assertEquals( "default", rule.getVariableValueFromObject( mojo, "withDefault" ) );
+        assertEquals( "propertyValue", rule.getVariableValueFromObject( mojo, "withProperty" ) );
+        assertEquals( "propertyValue", rule.getVariableValueFromObject( mojo, "withPropertyAndDefault" ) );
+    }
+
 }

--- a/maven-plugin-testing-harness/src/test/projects/property/pom.xml
+++ b/maven-plugin-testing-harness/src/test/projects/property/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test</groupId>
+  <artifactId>test-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <property>propertyValue</property>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>test</groupId>
+        <artifactId>test-plugin</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Neither MojoRule.lookupConfiguredMojo nor the underlying method in AbstractMojoTestCase allows initialising the constructed mojo with the values from the project pom. Filling that gap.

Added a small unit test demonstrating the idea.