### PR TITLE
[MPLUGINTESTING-74] Using generics to return the matched type for lookup and getVariableValue methods

### DIFF
--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/AbstractMojoTestCase.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/AbstractMojoTestCase.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import com.google.inject.Module;
 import org.apache.commons.io.input.XmlStreamReader;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
@@ -80,8 +81,6 @@ import org.codehaus.plexus.util.ReflectionUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
-
-import com.google.inject.Module;
 
 /**
  * TODO: add a way to use the plugin POM for the lookup so that the user doesn't have to provide the a:g:v:goal
@@ -304,7 +303,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo lookupMojo( String goal, String pluginPom )
+    protected <T extends Mojo> T lookupMojo( String goal, String pluginPom )
         throws Exception
     {
         return lookupMojo( goal, new File( pluginPom ) );
@@ -318,7 +317,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo lookupEmptyMojo( String goal, String pluginPom )
+    protected <T extends Mojo> T lookupEmptyMojo( String goal, String pluginPom )
         throws Exception
     {
         return lookupEmptyMojo( goal, new File( pluginPom ) );
@@ -332,7 +331,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo lookupMojo( String goal, File pom )
+    protected <T extends Mojo> T lookupMojo( String goal, File pom )
         throws Exception
     {
         File pluginPom = new File( getBasedir(), "pom.xml" );
@@ -358,7 +357,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo lookupEmptyMojo( String goal, File pom )
+    protected <T extends Mojo> T lookupEmptyMojo( String goal, File pom )
         throws Exception
     {
         File pluginPom = new File( getBasedir(), "pom.xml" );
@@ -394,7 +393,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo lookupMojo( String groupId, String artifactId, String version, String goal,
+    protected <T extends Mojo> T lookupMojo( String groupId, String artifactId, String version, String goal,
                                PlexusConfiguration pluginConfiguration )
         throws Exception
     {
@@ -402,7 +401,7 @@ public abstract class AbstractMojoTestCase
 
         // pluginkey = groupId : artifactId : version : goal
 
-        Mojo mojo = lookup( Mojo.class, groupId + ":" + artifactId + ":" + version + ":" + goal );
+        T mojo = (T) lookup( Mojo.class, groupId + ":" + artifactId + ":" + version + ":" + goal );
 
         LoggerManager loggerManager = getContainer().lookup( LoggerManager.class );
         
@@ -425,21 +424,21 @@ public abstract class AbstractMojoTestCase
     }
 
     /**
-     * 
+     *
      * @param project
      * @param goal
      * @return
      * @throws Exception
      * @since 2.0
      */
-    protected Mojo lookupConfiguredMojo( MavenProject project, String goal )
+    protected <T extends Mojo> T lookupConfiguredMojo( MavenProject project, String goal )
         throws Exception
     {
         return lookupConfiguredMojo( newMavenSession( project ), newMojoExecution( goal ) );
     }
 
     /**
-     * 
+     *
      * @param session
      * @param execution
      * @return
@@ -447,13 +446,13 @@ public abstract class AbstractMojoTestCase
      * @throws ComponentConfigurationException
      * @since 2.0
      */
-    protected Mojo lookupConfiguredMojo( MavenSession session, MojoExecution execution )
+    protected <T extends Mojo> T lookupConfiguredMojo( MavenSession session, MojoExecution execution )
         throws Exception, ComponentConfigurationException
     {
         MavenProject project = session.getCurrentProject();
         MojoDescriptor mojoDescriptor = execution.getMojoDescriptor();
 
-        Mojo mojo = (Mojo) lookup( mojoDescriptor.getRole(), mojoDescriptor.getRoleHint() );
+        T mojo = (T) lookup( mojoDescriptor.getRole(), mojoDescriptor.getRoleHint() );
 
         ExpressionEvaluator evaluator = new PluginParameterExpressionEvaluator( session, execution );
 
@@ -639,7 +638,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo configureMojo( Mojo mojo, String artifactId, File pom )
+    protected <T extends Mojo> T configureMojo( T mojo, String artifactId, File pom )
         throws Exception
     {
         validateContainerStatus();
@@ -661,7 +660,7 @@ public abstract class AbstractMojoTestCase
      * @return a Mojo instance
      * @throws Exception
      */
-    protected Mojo configureMojo( Mojo mojo, PlexusConfiguration pluginConfiguration )
+    protected <T extends Mojo> T configureMojo( T mojo, PlexusConfiguration pluginConfiguration )
         throws Exception
     {
         validateContainerStatus();
@@ -683,14 +682,14 @@ public abstract class AbstractMojoTestCase
      * @return object value of variable
      * @throws IllegalArgumentException
      */
-    protected Object getVariableValueFromObject( Object object, String variable )
+    protected <T> T getVariableValueFromObject( Object object, String variable )
         throws IllegalAccessException
     {
         Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses( variable, object.getClass() );
 
         field.setAccessible( true );
 
-        return field.get( object );
+        return (T) field.get( object );
     }
 
     /**
@@ -748,7 +747,7 @@ public abstract class AbstractMojoTestCase
      * @param value
      * @throws IllegalAccessException
      */
-    protected void setVariableValueToObject( Object object, String variable, Object value )
+    protected <T> void setVariableValueToObject( Object object, String variable, T value )
         throws IllegalAccessException
     {
         Field field = ReflectionUtils.getFieldByNameIncludingSuperclasses( variable, object.getClass() );

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/MojoRule.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/MojoRule.java
@@ -132,7 +132,7 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupMojo( String goal, String pluginPom )
+    public <T extends Mojo> T lookupMojo( String goal, String pluginPom )
         throws Exception
     {
         return testCase.lookupMojo( goal, pluginPom );
@@ -146,7 +146,7 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupEmptyMojo( String goal, String pluginPom )
+    public <T extends Mojo> T lookupEmptyMojo( String goal, String pluginPom )
         throws Exception
     {
         return testCase.lookupEmptyMojo( goal, new File( pluginPom ) );
@@ -160,7 +160,7 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupMojo( String goal, File pom )
+    public <T extends Mojo> T lookupMojo( String goal, File pom )
         throws Exception
     {
         return testCase.lookupMojo( goal, pom );
@@ -174,26 +174,26 @@ public class MojoRule
      * @return a Mojo instance
      * @throws Exception
      */
-    public Mojo lookupEmptyMojo( String goal, File pom )
+    public <T extends Mojo> T lookupEmptyMojo( String goal, File pom )
         throws Exception
     {
         return testCase.lookupEmptyMojo( goal, pom );
     }
 
-    public Mojo lookupMojo( String groupId, String artifactId, String version, String goal,
+    public <T extends Mojo> T lookupMojo( String groupId, String artifactId, String version, String goal,
                                PlexusConfiguration pluginConfiguration )
         throws Exception
     {
         return testCase.lookupMojo( groupId, artifactId, version, goal, pluginConfiguration );
     }
 
-    public Mojo lookupConfiguredMojo( MavenProject project, String goal )
+    public <T extends Mojo> T lookupConfiguredMojo( MavenProject project, String goal )
         throws Exception
     {
         return testCase.lookupConfiguredMojo( project, goal );
     }
 
-    public Mojo lookupConfiguredMojo( MavenSession session, MojoExecution execution )
+    public <T extends Mojo> T lookupConfiguredMojo( MavenSession session, MojoExecution execution )
         throws Exception, ComponentConfigurationException
     {
         return testCase.lookupConfiguredMojo( session, execution );
@@ -221,13 +221,13 @@ public class MojoRule
         return testCase.extractPluginConfiguration( artifactId, pomDom );
     }
 
-    public Mojo configureMojo( Mojo mojo, String artifactId, File pom )
+    public <T extends Mojo> T configureMojo( T mojo, String artifactId, File pom )
         throws Exception
     {
         return testCase.configureMojo( mojo, artifactId, pom );
     }
 
-    public Mojo configureMojo( Mojo mojo, PlexusConfiguration pluginConfiguration )
+    public <T extends Mojo> T configureMojo( T mojo, PlexusConfiguration pluginConfiguration )
         throws Exception
     {
         return testCase.configureMojo( mojo, pluginConfiguration );
@@ -243,7 +243,7 @@ public class MojoRule
      * @return object value of variable
      * @throws IllegalArgumentException
      */
-    public Object getVariableValueFromObject( Object object, String variable )
+    public <T> T getVariableValueFromObject( Object object, String variable )
         throws IllegalAccessException
     {
         return testCase.getVariableValueFromObject( object, variable );
@@ -286,7 +286,7 @@ public class MojoRule
      * @param value
      * @throws IllegalAccessException
      */
-    public void setVariableValueToObject( Object object, String variable, Object value )
+    public <T> void setVariableValueToObject( Object object, String variable, T value )
         throws IllegalAccessException
     {
         testCase.setVariableValueToObject( object, variable, value );
@@ -350,7 +350,7 @@ public class MojoRule
     /**
      * @since 3.1.0
      */
-    public Mojo lookupConfiguredMojo( File basedir, String goal )
+    public <T extends Mojo> T lookupConfiguredMojo( File basedir, String goal )
         throws Exception, ComponentConfigurationException
     {
         MavenProject project = readMavenProject( basedir );

--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/MojoRuleTest.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/MojoRuleTest.java
@@ -19,17 +19,20 @@ package org.apache.maven.plugin.testing;
  * under the License.
  */
 
+import java.io.File;
+import java.io.StringReader;
+import java.util.Map;
+
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
-
-import java.io.StringReader;
-import java.util.Map;
-import org.junit.Rule;
-
-import static org.junit.Assert.*;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Mirko Friedenhagen
@@ -95,7 +98,7 @@ public class MojoRuleTest
     {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         assertEquals( "valueOne", mojo.getKeyOne() );
 
@@ -111,7 +114,7 @@ public class MojoRuleTest
     {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         assertEquals( "valueOne", rule.getVariableValueFromObject( mojo, "keyOne" ) );
 
@@ -127,7 +130,7 @@ public class MojoRuleTest
      {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         Map<String, Object> map = rule.getVariablesAndValuesFromObject( mojo );
 
@@ -145,7 +148,7 @@ public class MojoRuleTest
     {
         SimpleMojo mojo = new SimpleMojo();
 
-        mojo = (SimpleMojo) rule.configureMojo( mojo, pluginConfiguration );
+        mojo = rule.configureMojo( mojo, pluginConfiguration );
 
         rule.setVariableValueToObject( mojo, "keyOne", "myValueOne" );
 
@@ -165,4 +168,19 @@ public class MojoRuleTest
     {
         assertTrue( "before executed because WithMojo annotation was not added", beforeWasCalled );
     }
+
+    /**
+     * @throws Exception if any
+     */
+    @Test
+    public void testLookupInitializedMojo()
+            throws Exception
+    {
+        File pomBaseDir = new File( "src/test/projects/property" );
+        ParametersMojo mojo = rule.lookupConfiguredMojo( pomBaseDir, "parameters" );
+        assertEquals( "default", rule.getVariableValueFromObject( mojo, "withDefault" ) );
+        assertEquals( "propertyValue", rule.getVariableValueFromObject( mojo, "withProperty" ) );
+        assertEquals( "propertyValue", rule.getVariableValueFromObject( mojo, "withPropertyAndDefault" ) );
+    }
+
 }

--- a/maven-plugin-testing-harness/src/test/projects/property/pom.xml
+++ b/maven-plugin-testing-harness/src/test/projects/property/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test</groupId>
+  <artifactId>test-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <property>propertyValue</property>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>test</groupId>
+        <artifactId>test-plugin</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Minor improvement, uses generics to derive the type of created mojos and objects retrieved using the `getVariableValue` call.