### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/api/plugin/testing/ExpressionEvaluatorTest.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/api/plugin/testing/ExpressionEvaluatorTest.java
@@ -27,7 +27,6 @@ import com.google.inject.Provides;
 import org.apache.maven.api.Session;
 import org.apache.maven.api.plugin.MojoException;
 import org.apache.maven.api.plugin.testing.stubs.SessionStub;
-import org.codehaus.plexus.util.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -72,11 +71,11 @@ public class ExpressionEvaluatorTest {
         /** {@inheritDoc} */
         @Override
         public void execute() throws MojoException {
-            if (StringUtils.isEmpty(basedir)) {
+            if (basedir == null || basedir.isEmpty()) {
                 throw new MojoException("basedir was not injected.");
             }
 
-            if (StringUtils.isEmpty(workdir)) {
+            if (workdir == null || workdir.isEmpty()) {
                 throw new MojoException("workdir was not injected.");
             } else if (!workdir.startsWith(basedir)) {
                 throw new MojoException("workdir does not start with basedir.");

--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/ExpressionEvaluatorMojo.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/ExpressionEvaluatorMojo.java
@@ -22,7 +22,6 @@ import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * @author Edwin Punzalan
@@ -37,7 +36,7 @@ public class ExpressionEvaluatorMojo extends AbstractMojo {
     /** {@inheritDoc} */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (StringUtils.isEmpty(basedir)) {
+        if (basedir == null || basedir.isEmpty()) {
             throw new MojoExecutionException("basedir was not injected.");
         }
 
@@ -45,7 +44,7 @@ public class ExpressionEvaluatorMojo extends AbstractMojo {
             throw new MojoExecutionException("localRepository was not injected.");
         }
 
-        if (StringUtils.isEmpty(workdir)) {
+        if (workdir == null || workdir.isEmpty()) {
             throw new MojoExecutionException("workdir was not injected.");
         } else if (!workdir.startsWith(basedir)) {
             throw new MojoExecutionException("workdir does not start with basedir.");


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu