### PR TITLE
Set core dependency to Maven 4.0.0-beta4.

### DIFF
--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/ArtifactStub.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/ArtifactStub.java
@@ -20,8 +20,8 @@ package org.apache.maven.api.plugin.testing.stubs;
 
 import java.util.Objects;
 
-import org.apache.maven.api.Artifact;
-import org.apache.maven.api.ArtifactCoordinate;
+import org.apache.maven.api.ArtifactCoordinates;
+import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Version;
 import org.apache.maven.api.VersionConstraint;
 import org.apache.maven.api.annotations.Nonnull;
@@ -32,7 +32,7 @@ import org.eclipse.aether.util.version.GenericVersionScheme;
 /**
  *
  */
-public class ArtifactStub implements Artifact {
+public class ArtifactStub implements ProducedArtifact {
     private String groupId;
     private String artifactId;
     private String classifier;
@@ -96,6 +96,7 @@ public class ArtifactStub implements Artifact {
         this.version = version;
     }
 
+    @Override
     public Version getBaseVersion() {
         return getParser().parseVersion(baseVersion != null ? baseVersion : version);
     }
@@ -120,8 +121,8 @@ public class ArtifactStub implements Artifact {
     }
 
     @Override
-    public ArtifactCoordinate toCoordinate() {
-        return new ArtifactCoordinate() {
+    public ArtifactCoordinates toCoordinates() {
+        return new ArtifactCoordinates() {
             @Override
             public String getGroupId() {
                 return groupId;
@@ -138,7 +139,7 @@ public class ArtifactStub implements Artifact {
             }
 
             @Override
-            public VersionConstraint getVersion() {
+            public VersionConstraint getVersionConstraint() {
                 return getParser().parseVersionConstraint(version);
             }
 

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/ProjectStub.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/ProjectStub.java
@@ -39,7 +39,7 @@ public class ProjectStub implements Project {
     private boolean topProject;
     private Path rootDirectory;
     private Map<String, String> properties = new HashMap<>();
-    private Artifact mainArtifact;
+    private ProducedArtifact mainArtifact;
 
     public void setModel(Model model) {
         this.model = model;
@@ -119,8 +119,8 @@ public class ProjectStub implements Project {
     }
 
     @Override
-    public List<Artifact> getArtifacts() {
-        Artifact pomArtifact = new ArtifactStub(getGroupId(), getArtifactId(), "", getVersion(), "pom");
+    public List<ProducedArtifact> getArtifacts() {
+        ProducedArtifact pomArtifact = new ArtifactStub(getGroupId(), getArtifactId(), "", getVersion(), "pom");
         return mainArtifact != null ? Arrays.asList(pomArtifact, mainArtifact) : Arrays.asList(pomArtifact);
     }
 
@@ -138,13 +138,13 @@ public class ProjectStub implements Project {
 
     @Nonnull
     @Override
-    public List<DependencyCoordinate> getDependencies() {
+    public List<DependencyCoordinates> getDependencies() {
         return null;
     }
 
     @Nonnull
     @Override
-    public List<DependencyCoordinate> getManagedDependencies() {
+    public List<DependencyCoordinates> getManagedDependencies() {
         return null;
     }
 
@@ -212,7 +212,7 @@ public class ProjectStub implements Project {
         return this;
     }
 
-    public ProjectStub setMainArtifact(Artifact mainArtifact) {
+    public ProjectStub setMainArtifact(ProducedArtifact mainArtifact) {
         this.mainArtifact = mainArtifact;
         return this;
     }

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/SessionMock.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/SessionMock.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.LocalRepository;
+import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.RemoteRepository;
 import org.apache.maven.api.Session;
@@ -223,7 +224,7 @@ public class SessionMock {
                     Project project = iom.getArgument(1, Project.class);
                     String type = iom.getArgument(2, String.class);
                     Path path = iom.getArgument(3, Path.class);
-                    Artifact artifact = session.createArtifact(
+                    ProducedArtifact artifact = session.createProducedArtifact(
                             project.getGroupId(), project.getArtifactId(), project.getVersion(), null, null, type);
                     artifactManager.setPath(artifact, path);
                     attachedArtifacts
@@ -235,7 +236,7 @@ public class SessionMock {
                 .attachArtifact(same(session), any(Project.class), any(), any());
         doAnswer(iom -> {
                     Project project = iom.getArgument(0, Project.class);
-                    Artifact artifact = iom.getArgument(1, Artifact.class);
+                    ProducedArtifact artifact = iom.getArgument(1, ProducedArtifact.class);
                     Path path = iom.getArgument(2, Path.class);
                     artifactManager.setPath(artifact, path);
                     attachedArtifacts
@@ -244,7 +245,7 @@ public class SessionMock {
                     return null;
                 })
                 .when(projectManager)
-                .attachArtifact(any(Project.class), any(Artifact.class), any(Path.class));
+                .attachArtifact(any(Project.class), any(ProducedArtifact.class), any(Path.class));
         when(projectManager.getAttachedArtifacts(any()))
                 .then(iom ->
                         attachedArtifacts.computeIfAbsent(iom.getArgument(0, Project.class), p -> new ArrayList<>()));

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/SessionStub.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/stubs/SessionStub.java
@@ -27,10 +27,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.maven.api.Artifact;
-import org.apache.maven.api.ArtifactCoordinate;
+import org.apache.maven.api.ArtifactCoordinates;
 import org.apache.maven.api.Dependency;
-import org.apache.maven.api.DependencyCoordinate;
+import org.apache.maven.api.DependencyCoordinates;
 import org.apache.maven.api.DependencyScope;
+import org.apache.maven.api.DownloadedArtifact;
 import org.apache.maven.api.Language;
 import org.apache.maven.api.Listener;
 import org.apache.maven.api.LocalRepository;
@@ -38,6 +39,7 @@ import org.apache.maven.api.Node;
 import org.apache.maven.api.Packaging;
 import org.apache.maven.api.PathScope;
 import org.apache.maven.api.PathType;
+import org.apache.maven.api.ProducedArtifact;
 import org.apache.maven.api.Project;
 import org.apache.maven.api.ProjectScope;
 import org.apache.maven.api.RemoteRepository;
@@ -107,6 +109,7 @@ public class SessionStub implements Session {
     }
 
     @Nonnull
+    @Override
     public Map<String, String> getEffectiveProperties(@Nullable Project project) {
         HashMap<String, String> result = new HashMap<>(getSystemProperties());
         if (project != null) {
@@ -219,58 +222,70 @@ public class SessionStub implements Session {
     }
 
     @Override
-    public ArtifactCoordinate createArtifactCoordinate(String s, String s1, String s2, String s3) {
+    public ProducedArtifact createProducedArtifact(
+            String groupId, String artifactId, String version, String extension) {
         return null;
     }
 
     @Override
-    public ArtifactCoordinate createArtifactCoordinate(String coordString) {
+    public ProducedArtifact createProducedArtifact(
+            String groupId, String artifactId, String version, String classifier, String extension, String type) {
         return null;
     }
 
     @Override
-    public ArtifactCoordinate createArtifactCoordinate(
+    public ArtifactCoordinates createArtifactCoordinates(String s, String s1, String s2, String s3) {
+        return null;
+    }
+
+    @Override
+    public ArtifactCoordinates createArtifactCoordinates(String coordString) {
+        return null;
+    }
+
+    @Override
+    public ArtifactCoordinates createArtifactCoordinates(
             String s, String s1, String s2, String s3, String s4, String s5) {
         return null;
     }
 
     @Override
-    public ArtifactCoordinate createArtifactCoordinate(Artifact artifact) {
+    public ArtifactCoordinates createArtifactCoordinates(Artifact artifact) {
         return null;
     }
 
     @Override
-    public DependencyCoordinate createDependencyCoordinate(ArtifactCoordinate artifactCoordinate) {
+    public DependencyCoordinates createDependencyCoordinates(ArtifactCoordinates artifactCoordinate) {
         return null;
     }
 
     @Override
-    public DependencyCoordinate createDependencyCoordinate(Dependency dependency) {
+    public DependencyCoordinates createDependencyCoordinates(Dependency dependency) {
         return null;
     }
 
     @Override
-    public Map.Entry<Artifact, Path> resolveArtifact(Artifact artifact) {
+    public DownloadedArtifact resolveArtifact(Artifact artifact) {
         return null;
     }
 
     @Override
-    public Map.Entry<Artifact, Path> resolveArtifact(ArtifactCoordinate coordinate) {
+    public DownloadedArtifact resolveArtifact(ArtifactCoordinates coordinate) {
         return null;
     }
 
     @Override
-    public Map<Artifact, Path> resolveArtifacts(ArtifactCoordinate... artifactCoordinates) {
+    public Collection<DownloadedArtifact> resolveArtifacts(ArtifactCoordinates... artifactCoordinates) {
         return null;
     }
 
     @Override
-    public Map<Artifact, Path> resolveArtifacts(Collection<? extends ArtifactCoordinate> collection) {
+    public Collection<DownloadedArtifact> resolveArtifacts(Collection<? extends ArtifactCoordinates> collection) {
         return null;
     }
 
     @Override
-    public Map<Artifact, Path> resolveArtifacts(Artifact... artifacts) {
+    public Collection<DownloadedArtifact> resolveArtifacts(Artifact... artifacts) {
         return null;
     }
 
@@ -280,12 +295,12 @@ public class SessionStub implements Session {
     }
 
     @Override
-    public List<Path> resolveDependencies(DependencyCoordinate dependencyCoordinate) {
+    public List<Path> resolveDependencies(DependencyCoordinates dependencyCoordinate) {
         return null;
     }
 
     @Override
-    public List<Path> resolveDependencies(List<DependencyCoordinate> dependencyCoordinates) {
+    public List<Path> resolveDependencies(List<DependencyCoordinates> dependencyCoordinates) {
         return null;
     }
 
@@ -295,12 +310,12 @@ public class SessionStub implements Session {
     }
 
     @Override
-    public Version resolveVersion(ArtifactCoordinate artifact) {
+    public Version resolveVersion(ArtifactCoordinates artifact) {
         return null;
     }
 
     @Override
-    public List<Version> resolveVersionRange(ArtifactCoordinate artifact) {
+    public List<Version> resolveVersionRange(ArtifactCoordinates artifact) {
         return null;
     }
 
@@ -314,7 +329,7 @@ public class SessionStub implements Session {
     public void deployArtifact(RemoteRepository repository, Artifact... artifacts) {}
 
     @Override
-    public void setArtifactPath(Artifact artifact, Path path) {}
+    public void setArtifactPath(ProducedArtifact artifact, Path path) {}
 
     @Override
     public Optional<Path> getArtifactPath(Artifact artifact) {
@@ -337,7 +352,7 @@ public class SessionStub implements Session {
     }
 
     @Override
-    public Node collectDependencies(DependencyCoordinate dependencyCoordinate) {
+    public Node collectDependencies(DependencyCoordinates dependencyCoordinate) {
         return null;
     }
 
@@ -368,7 +383,7 @@ public class SessionStub implements Session {
 
     @Override
     public Map<PathType, List<Path>> resolveDependencies(
-            DependencyCoordinate dependencyCoordinate, PathScope scope, Collection<PathType> desiredTypes) {
+            DependencyCoordinates dependencyCoordinate, PathScope scope, Collection<PathType> desiredTypes) {
         return Map.of();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ under the License.
 
   <properties>
     <surefire.version>3.2.1</surefire.version>
-    <mavenVersion>4.0.0-beta-3</mavenVersion>
+    <mavenVersion>4.0.0-beta-4</mavenVersion>
     <maven.site.path>plugin-testing-archives/LATEST</maven.site.path>
     <javaVersion>17</javaVersion>
     <project.build.outputTimestamp>2024-06-26T07:42:15Z</project.build.outputTimestamp>


### PR DESCRIPTION
The following interfaces from beta 3 have been renamed in beta 4:

* `org.apache.maven.api.DependencyCoordinate`
* `org.apache.maven.api.services.DependencyCoordinateFactory`
* `org.apache.maven.api.services.DependencyCoordinateFactoryRequest`
