### PR TITLE
Use default pom.xml when Basedir is set

### DIFF
--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/ParametersMojoTest.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/ParametersMojoTest.java
@@ -218,4 +218,20 @@ public class ParametersMojoTest {
             assertDoesNotThrow(mojo::execute);
         }
     }
+
+    @Test
+    @Basedir("src/test/projects/basedir-set-by-annotation")
+    @InjectMojo(goal = "test:test-plugin:0.0.1-SNAPSHOT:parameters")
+    void basedirInjectedWithBasedirAnnotationDefaultPom(ParametersMojo mojo) {
+        assertEquals("i-have-a-basedir-set-by-annotation", mojo.getPlain());
+        assertDoesNotThrow(mojo::execute);
+    }
+
+    @Test
+    @Basedir("/projects/basedir-set-by-annotation-classpath")
+    @InjectMojo(goal = "parameters")
+    void basedirInjectedWithBasedirFromClasspathAnnotationDefaultPom(ParametersMojo mojo) {
+        assertEquals("i-have-a-basedir-set-by-annotation-classpath", mojo.getPlain());
+        assertDoesNotThrow(mojo::execute);
+    }
 }


### PR DESCRIPTION
When Basedir is explicit set we can try to find a pom.xml we can not use a default pom.xml with default basedir which point to project basedir

Following this checklist to help us incorporate your contribution quickly and easily:

- [ ] Your pull request should address just one issue, without pulling in other changes.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [ ] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.


If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [ ] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
