### PR TITLE
chore: Replace PlexusTestCase by PlexusExtension in MavenProjectStub

### DIFF
--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/stubs/MavenProjectStub.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/plugin/testing/stubs/MavenProjectStub.java
@@ -57,7 +57,7 @@ import org.apache.maven.model.Resource;
 import org.apache.maven.model.Scm;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.testing.PlexusExtension;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -288,7 +288,7 @@ public class MavenProjectStub extends MavenProject {
     /** {@inheritDoc} */
     @Override
     public File getBasedir() {
-        return new File(PlexusTestCase.getBasedir());
+        return new File(PlexusExtension.getBasedir());
     }
 
     /**


### PR DESCRIPTION
Replace PlexusTestCase by PlexusExtension to reduce the need of junit4.

During migration from AbstractMojoTestCase to MojoTest the dependency `jupiter-vintage` is still needed when your test code uses MavenProjectStub.