### PR TITLE
Improve InjectMojo annotation processing

### DIFF
--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/Basedir.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/Basedir.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
 
 /**
  * Specifies the base directory for test resources in Maven plugin tests.
- * This annotation can be applied to test methods to define where test resources are located.
+ * This annotation can be applied to test methods, or test class, to define where test resources are located.
  *
  ** <p>Example usage:</p>
  * <pre>
@@ -50,7 +50,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Target(ElementType.METHOD)
+@Target({ElementType.TYPE, ElementType.METHOD})
 public @interface Basedir {
     String value() default "";
 }

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/InjectMojo.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/InjectMojo.java
@@ -82,7 +82,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.PARAMETER})
 public @interface InjectMojo {
 
     String goal();

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
@@ -145,8 +145,9 @@ public class MojoExtension extends PlexusExtension implements ParameterResolver 
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
             throws ParameterResolutionException {
-        return parameterContext.isAnnotated(InjectMojo.class)
-                || parameterContext.getDeclaringExecutable().isAnnotationPresent(InjectMojo.class);
+        return Mojo.class.isAssignableFrom(parameterContext.getParameter().getType())
+                && (parameterContext.isAnnotated(InjectMojo.class)
+                        || parameterContext.getDeclaringExecutable().isAnnotationPresent(InjectMojo.class));
     }
 
     @Override

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoExtension.java
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -158,8 +158,13 @@ public class MojoExtension extends PlexusExtension implements ParameterResolver 
                     .findAnnotation(InjectMojo.class)
                     .orElseGet(() -> parameterContext.getDeclaringExecutable().getAnnotation(InjectMojo.class));
 
-            Set<MojoParameter> mojoParameters =
-                    new HashSet<>(parameterContext.findRepeatableAnnotations(MojoParameter.class));
+            Set<MojoParameter> mojoParameters = new LinkedHashSet<>();
+
+            extensionContext
+                    .getTestClass()
+                    .map(c -> c.getAnnotationsByType(MojoParameter.class))
+                    .map(Arrays::asList)
+                    .ifPresent(mojoParameters::addAll);
 
             Optional.ofNullable(parameterContext.getDeclaringExecutable().getAnnotation(MojoParameter.class))
                     .ifPresent(mojoParameters::add);
@@ -168,6 +173,8 @@ public class MojoExtension extends PlexusExtension implements ParameterResolver 
                     .map(MojoParameters::value)
                     .map(Arrays::asList)
                     .ifPresent(mojoParameters::addAll);
+
+            mojoParameters.addAll(parameterContext.findRepeatableAnnotations(MojoParameter.class));
 
             Class<?> holder = parameterContext.getTarget().get().getClass();
             PluginDescriptor descriptor =
@@ -182,7 +189,11 @@ public class MojoExtension extends PlexusExtension implements ParameterResolver 
     public void beforeEach(ExtensionContext context) throws Exception {
         String basedir = AnnotationSupport.findAnnotation(context.getElement().get(), Basedir.class)
                 .map(Basedir::value)
-                .orElse(null);
+                .orElseGet(() -> {
+                    return AnnotationSupport.findAnnotation(context.getTestClass(), Basedir.class)
+                            .map(Basedir::value)
+                            .orElse(null);
+                });
 
         if (basedir == null) {
             basedir = getBasedir();

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoParameter.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoParameter.java
@@ -31,9 +31,9 @@ import java.lang.annotation.Target;
  * without requiring a full POM file.
  *
  * <p>The annotation is repeatable, allowing multiple parameters to be set
- * on a single test method or parameter. For multiple parameters, you can
- * either use multiple {@code @MojoParameter} annotations or a single
- * {@link MojoParameters} annotation.</p>
+ * on a single test method, parameter, or on the whole test class. For
+ * multiple parameters, you can either use multiple {@code @MojoParameter}
+ * annotations or a single {@link MojoParameters} annotation.</p>
  *
  * <p>Example usage with a single parameter:</p>
  * <pre>
@@ -69,7 +69,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(MojoParameters.class)
 @Inherited
-@Target(ElementType.METHOD)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
 public @interface MojoParameter {
     String name();
 

--- a/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoParameters.java
+++ b/maven-plugin-testing-harness/src/main/java/org/apache/maven/api/plugin/testing/MojoParameters.java
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
-@Target(ElementType.METHOD)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PARAMETER})
 public @interface MojoParameters {
     MojoParameter[] value();
 }

--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/AnnotationLevelMojoTest.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/AnnotationLevelMojoTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugin.testing;
+
+import org.apache.maven.api.plugin.testing.Basedir;
+import org.apache.maven.api.plugin.testing.InjectMojo;
+import org.apache.maven.api.plugin.testing.MojoExtension;
+import org.apache.maven.api.plugin.testing.MojoParameter;
+import org.apache.maven.api.plugin.testing.MojoTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MojoTest
+@Basedir("class-basedir")
+@MojoParameter(name = "plain", value = "class-value")
+class AnnotationLevelMojoTest {
+
+    @Test
+    @InjectMojo(goal = "parameters")
+    void classLevelValues(ParametersMojo mojo) {
+        assertEquals("class-value", mojo.getPlain());
+        assertTrue(
+                MojoExtension.getBasedir().endsWith("class-basedir"),
+                "Basedir value did not came from class annotation");
+    }
+
+    @Test
+    @InjectMojo(goal = "parameters")
+    @Basedir("method-basedir")
+    @MojoParameter(name = "plain", value = "method-value")
+    void methodLevelValues(ParametersMojo mojo) {
+        assertEquals("method-value", mojo.getPlain());
+        assertTrue(
+                MojoExtension.getBasedir().endsWith("method-basedir"),
+                "Basedir value did not came from method annotation");
+    }
+
+    @Test
+    void parameterLevelValues(
+            @InjectMojo(goal = "parameters") @MojoParameter(name = "plain", value = "param-level-param-value")
+                    ParametersMojo mojo) {
+        assertEquals("param-level-param-value", mojo.getPlain());
+    }
+
+    @Test
+    @MojoParameter(name = "plain", value = "method-value")
+    void mojoParameterOnMethod(
+            @InjectMojo(goal = "parameters") ParametersMojo mojo,
+            @InjectMojo(goal = "parameters") @MojoParameter(name = "plain", value = "param-value")
+                    ParametersMojo alternateMojo) {
+        assertEquals("method-value", mojo.getPlain());
+        assertEquals("param-value", alternateMojo.getPlain());
+    }
+}

--- a/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/ParametersMojoTest.java
+++ b/maven-plugin-testing-harness/src/test/java/org/apache/maven/plugin/testing/ParametersMojoTest.java
@@ -33,9 +33,11 @@ import org.apache.maven.plugin.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MojoTest
@@ -233,5 +235,12 @@ public class ParametersMojoTest {
     void basedirInjectedWithBasedirFromClasspathAnnotationDefaultPom(ParametersMojo mojo) {
         assertEquals("i-have-a-basedir-set-by-annotation-classpath", mojo.getPlain());
         assertDoesNotThrow(mojo::execute);
+    }
+
+    @Test
+    @InjectMojo(goal = "test:test-plugin:0.0.1-SNAPSHOT:parameters")
+    void testMultipleResolvedParameters(ParametersMojo mojo, TestInfo testInfo) {
+        assertNotNull(mojo);
+        assertNotNull(testInfo);
     }
 }


### PR DESCRIPTION
This pull request addresses issue #244 

The JUnit MojoExtension is now compatible with other parameter resolvers.

The various annotations can now also be used on class or even parameter levels.

`@InjectMojo` can be used on methods and individual parameters.

`@Basedir` can also be used on the test class. Which can then be overridden on a test method.

`@MojoParameter` can be defined on test class, test method, or individual parameters. They are processed in that order, giving the values defined on the parameter the highest priority.

---

Following this checklist to help us incorporate your contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.


If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
